### PR TITLE
Gave a name to Coroutine GO

### DIFF
--- a/Assets/Scripts/Editor/CoroutineClassUnitTests.cs
+++ b/Assets/Scripts/Editor/CoroutineClassUnitTests.cs
@@ -121,7 +121,7 @@ namespace PubNubMessaging.Tests
 
             CoroutineParams<T> cp = new CoroutineParams<T> (url, timeout, 0, crt, typeof(T), pubnubRequestState);
 
-            GameObject go = new GameObject ();
+            GameObject go = new GameObject ("PubnubCoroutine");
             CoroutineClass cc = go.AddComponent<CoroutineClass> ();
 
             cc.SetCoroutineParams<T>(crt, cp);


### PR DESCRIPTION
Each GO must have a name to avoid confusion and to know it's source.