### PR TITLE
Fixed Signal callback

### DIFF
--- a/PubNubUnity/Assets/PubNub/Editor/SignalTest.cs
+++ b/PubNubUnity/Assets/PubNub/Editor/SignalTest.cs
@@ -22,6 +22,23 @@ namespace PubNubAPI.Tests
             TestSignalCommon (true, true);
         }
 
+        [Test]
+        public void TestAddListenerSignalCallback ()
+        {
+            PNConfiguration pnConfiguration = new PNConfiguration ();
+            PubNubUnity pnUnity = new PubNubUnity(pnConfiguration, null, null);
+            bool receivedCallback = false;
+            Action<PNSignalEventResult> callback = (pnser) => receivedCallback = true;
+            pnUnity.AddListener(null, null, null, callback, null, null, null, null);
+
+            pnUnity.RaiseEvent(new SubscribeEventEventArgs()
+            {
+                SignalEventResult = new PNSignalEventResult(null, null, null, 0, 0, null, null)
+            });
+
+            Assert.IsTrue(receivedCallback);
+        }
+
         public void TestSignalCommon(bool ssl, bool sendQueryParams){
             string channel = EditorCommon.GetRandomChannelName();
             string message = "Test signal";

--- a/PubNubUnity/Assets/PubNub/PubNubUnity/PubNubUnity.cs
+++ b/PubNubUnity/Assets/PubNub/PubNubUnity/PubNubUnity.cs
@@ -79,7 +79,7 @@ namespace PubNubAPI
                     if(mea.PresenceEventResult != null){
                         presenceCallback(mea.PresenceEventResult);
                     }
-                    if(mea.MessageResult != null){
+                    if(mea.SignalEventResult != null){
                         signalCallback(mea.SignalEventResult);
                     }
                     if(mea.UserEventResult != null){

--- a/PubNubUnity/Assets/PubNub/PubNubUnity/PubNubUnity.cs
+++ b/PubNubUnity/Assets/PubNub/PubNubUnity/PubNubUnity.cs
@@ -70,28 +70,28 @@ namespace PubNubAPI
                 #endif
                 
                 if(mea!=null){
-                    if(mea.Status != null){
+                    if(mea.Status != null && statusCallback != null){
                         statusCallback(mea.Status);
                     }
-                    if(mea.MessageResult != null){
+                    if(mea.MessageResult != null && messageCallback != null){
                         messageCallback(mea.MessageResult);
                     }
-                    if(mea.PresenceEventResult != null){
+                    if(mea.PresenceEventResult != null && presenceCallback != null){
                         presenceCallback(mea.PresenceEventResult);
                     }
-                    if(mea.SignalEventResult != null){
+                    if(mea.SignalEventResult != null && signalCallback != null){
                         signalCallback(mea.SignalEventResult);
                     }
-                    if(mea.UserEventResult != null){
+                    if(mea.UserEventResult != null && userCallback != null){
                         userCallback(mea.UserEventResult);
                     }
-                    if(mea.SpaceEventResult != null){
+                    if(mea.SpaceEventResult != null && spaceCallback != null){
                         spaceCallback(mea.SpaceEventResult);
                     }
-                    if(mea.MembershipEventResult != null){
+                    if(mea.MembershipEventResult != null && membershipCallback != null){
                         membershipCallback(mea.MembershipEventResult);
                     }
-                    if(mea.MessageActionsEventResult != null){
+                    if(mea.MessageActionsEventResult != null && messageActionsCallback != null){
                         messageActionsCallback(mea.MessageActionsEventResult);
                     }
 


### PR DESCRIPTION
We were trying to utilize pubnub signals, however I was never receiving the callback. Upon further investigation I found that when using AddListener() there is an incorrect null check to call signalCallback. Changing it to null check mea.SignalEventResult (the object the callback utilizes), allows it to function as expected