### PR TITLE
UUID changes

### DIFF
--- a/PubNubUnity/Assets/PubNub/Editor/EditorCommon.cs
+++ b/PubNubUnity/Assets/PubNub/Editor/EditorCommon.cs
@@ -50,6 +50,7 @@ namespace PubNubAPI.Tests
         public bool DeliveryStatus  { get; set; }
 
         public static PubNub InitPN(PNConfiguration pnConfig){
+            pnConfig.UUID = PubNub.GenerateUUID();
             return new PubNub(pnConfig);
         }
 
@@ -62,6 +63,7 @@ namespace PubNubAPI.Tests
             pnConfiguration.LogVerbosity = PNLogVerbosity.BODY; 
             pnConfiguration.PresenceTimeout = 60;
             pnConfiguration.PresenceInterval= 30;
+            pnConfiguration.UUID = PubNub.GenerateUUID();
             return pnConfiguration;
         }
 

--- a/PubNubUnity/Assets/PubNub/Editor/PNConfigurationTests.cs
+++ b/PubNubUnity/Assets/PubNub/Editor/PNConfigurationTests.cs
@@ -13,6 +13,7 @@ namespace PubNubAPI.Tests
         public void TestPNinGenerateGuid ()
         {
             PNConfiguration pnConfig = new PNConfiguration();
+            pnConfig.UUID = PubNub.GenerateUUID();
             Assert.IsTrue(pnConfig.UUID.Contains("pn-"));
         }
        #endif

--- a/PubNubUnity/Assets/PubNub/Examples/Example.cs
+++ b/PubNubUnity/Assets/PubNub/Examples/Example.cs
@@ -487,7 +487,7 @@ namespace PubNubExample
             pnConfiguration.HeartbeatNotificationOption = PNHeartbeatNotificationOption.All;
 
             //TODO: remove
-            pnConfiguration.UUID = "PubNubUnityExample";
+            pnConfiguration.UUID = PubNub.GenerateUUID();
             Debug.Log ("PNConfiguration");  
             pubnub = new PubNub (pnConfiguration);
 

--- a/PubNubUnity/Assets/PubNub/Helpers/CommonText.cs
+++ b/PubNubUnity/Assets/PubNub/Helpers/CommonText.cs
@@ -6,5 +6,6 @@ namespace PubNubAPI
     {
         internal static readonly string DuplicateChannelsOrChannelGroups = "Duplicate Channels or Channel Groups";
         internal static readonly string APNS2TopicEmpty = "Topic cannot be empty when APNS2 is selected";
+        internal static readonly string UUIDMissing = "UUID misisng, please set it in the PNConfig.";
     }
 }

--- a/PubNubUnity/Assets/PubNub/Helpers/Utility.cs
+++ b/PubNubUnity/Assets/PubNub/Helpers/Utility.cs
@@ -25,6 +25,12 @@ namespace PubNubAPI
             }
         }
         #endif  
+
+        public static void CheckUUID(string uuid){
+            if (string.IsNullOrEmpty (uuid) || string.IsNullOrEmpty (uuid.Trim ())) {
+                throw new PubNubException(CommonText.UUIDMissing);
+            }
+        }
     
         public static bool CheckDictionaryForError(Dictionary<string, object> dictionary, string keyName){
             if(dictionary.ContainsKey(keyName) && dictionary[keyName].Equals(true)){

--- a/PubNubUnity/Assets/PubNub/Models/Server/BuildRequests.cs
+++ b/PubNubUnity/Assets/PubNub/Models/Server/BuildRequests.cs
@@ -1300,6 +1300,7 @@ namespace PubNubAPI
         private static Uri BuildRestApiRequest<T> (List<string> urlComponents, PNOperationType type, string parameters, PubNubUnity pnInstance, Dictionary<string, string> queryParams)
         {
             string uuid = pnInstance.PNConfig.UUID;
+            Utility.CheckUUID(pnInstance.PNConfig.UUID);
             bool ssl = pnInstance.PNConfig.Secure;
             string origin = pnInstance.PNConfig.Origin;
             int pubnubPresenceHeartbeatInSeconds = pnInstance.PNConfig.PresenceTimeout;

--- a/PubNubUnity/Assets/PubNub/PlayModeTests/PlayModeCommon.cs
+++ b/PubNubUnity/Assets/PubNub/PlayModeTests/PlayModeCommon.cs
@@ -90,6 +90,7 @@ namespace PubNubAPI.Tests
             pnConfiguration.Origin = Origin;
             pnConfiguration.SubscribeKey = SubscribeKey;
             pnConfiguration.PublishKey = PublishKey;
+            pnConfiguration.UUID = PubNub.GenerateUUID();
             pnConfiguration.NonSubscribeTimeout = 30;
             if(withPAM){
                 pnConfiguration.SubscribeKey = SubscribeKeyPAM;

--- a/PubNubUnity/Assets/PubNub/PubNub.cs
+++ b/PubNubUnity/Assets/PubNub/PubNub.cs
@@ -72,6 +72,7 @@ namespace PubNubAPI
             this.jsonLibrary = jsonLibrary;
             this.gameObj = gameObjectRef;
             this.PNConfig = pnConfiguration;
+            Utility.CheckUUID(this.PNConfig.UUID);
             PubNubUnityInitializationAfterCleanup();
         }
 
@@ -100,6 +101,10 @@ namespace PubNubAPI
                     return null;
                 }
             }
+        }
+
+        public static string GenerateUUID(){
+            return string.Format("pn-{0}", Guid.NewGuid ().ToString ());
         }
 
         public void Reconnect(){

--- a/PubNubUnity/Assets/PubNub/PubNubUnity/PNConfiguration.cs
+++ b/PubNubUnity/Assets/PubNub/PubNubUnity/PNConfiguration.cs
@@ -29,14 +29,11 @@ namespace PubNubAPI
         private string uuid;
         public string UUID { 
             get{
-                if (string.IsNullOrEmpty (uuid) || string.IsNullOrEmpty (uuid.Trim ())) {
-                    uuid = string.Format("pn-{0}", Guid.NewGuid ().ToString ());
-                }
-
                 return uuid;
             }
             set{
                 uuid = value;
+                Utility.CheckUUID(uuid);
                 if(UUIDChanged!=null){
                     UUIDChanged.Invoke(this, null);
                 }


### PR DESCRIPTION
refactor(uuid): Breaking Change, UUID is not automatically generated by the SDK anymore. 

UUID is not automatically generated by the SDK anymore. Please set it in the PNConfig before instantiating the PubNub object.

footer:

Breaking Change: UUID is not automatically generated by the SDK anymore. 

 