### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PubNub Unity SDK (V4)
+# PubNub Unity SDK (V6)
 
 [![Build Status](https://travis-ci.com/pubnub/unity.svg?branch=master)](https://travis-ci.com/pubnub/unity) [![Build status](https://ci.appveyor.com/api/projects/status/1p3494pnt6rgqdsm/branch/master?svg=true)](https://ci.appveyor.com/project/PubNub/unity)
 
@@ -14,18 +14,39 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
 
 1. Download the PubNub Unity package from [this repository](https://github.com/pubnub/unity/releases/download/v6.0.5/PubNub.unitypackage).
 
-2. Import it to your Unity project by going to Assets -> Import Package -> Custom Package.
+2. Import the package to your Unity project by going to Assets > Import Package > Custom Package.
 
-3. Configure your keys:
+3. You will receive a number of compiler errors due to the PubNub Playmode tests. The errors can be resolved based on your Unity version.
+
+4. If you are using a recent Unity version (greater than 2018 LTS):
+    1. In the Project window, navigate to Assets > PubNub > PlayModeTests.
+    2. Right click the file **PlayModeTests.cs** and click delete. Press the Delete button in the pop-up dialog to confirm.
+    3. Let the Unity Editor compile to finalize these changes and remove all compiler errors.
+
+5. If you are using a Unity version equal to or older than 2018 LTS, you will need to enable the PubNub Unity package in the Test Runner:
+    1. Navigate to Window > General > Test Runner.
+    2. Click the mini drop down menu next to the window close button, and click Enable playmode tests for all assemblies.
+    3. Restart your Unity editor to finalize these changes.
+
+6. Configure your keys:
 
     ```csharp
+    using PubNubAPI;
     PNConfiguration pnConfiguration = new PNConfiguration();
     pnConfiguration.SubscribeKey = "my_subkey";
     pnConfiguration.PublishKey = "my_pubkey";
     pnConfiguration.SecretKey = "my_secretkey";
     pnConfiguration.LogVerbosity = PNLogVerbosity.BODY;
-    pnConfiguration.UUID = "myUniqueUUID"; 
+    pnConfiguration.UserId = "myUniqueUserId";
     ```
+
+7. If your Unity application contains existing [Assembly Definitions](https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html), you might receive [CS0246 compiler errors](https://support.unity.com/hc/en-us/articles/206116726-What-is-CS0246-), as the `PubNubAPI` namespace may not be recognized. You will need to create an assembly definition to use the `PubNubAPI` in your application.
+    1. Navigate to the Assets > PubNub folder in the Project window.
+    2. Right-click the PubNub folder and create an [Assembly Definition](https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html) by selecting Create > Assembly Definition. Assign a name to the asset (such as PubNub) and leave the default settings.
+    3. Navigate to the folder that you wish to use the `PubNubAPI` namespace. Click on the Assembly Definition file.
+    4. In the Inspector window, add the **PubNub** Assembly Definition you created earlier to the list of Assembly Definition References section by clicking on the **+** icon.
+    5. Scroll down in the Inspector window, and click Apply. The `PubNubAPI` namespace should now be visible in your application.
+    6. You may receive more compiler errors when trying to use the `PubNubAPI` namespace. These come from the PubNub > Editor folder, and contain test files. Delete the entire PubNub > Editor folder and allow the Unity editor to recompile changes.
 
 ## Add event listeners
 
@@ -34,61 +55,61 @@ pubnub.SubscribeCallback += SubscribeCallbackHandler;
 
 //Handler
 void SubscribeCallbackHandler(object sender, EventArgs e) {
-	SubscribeEventEventArgs mea = e as SubscribeEventEventArgs;
+    SubscribeEventEventArgs mea = e as SubscribeEventEventArgs;
 
-	if (mea.Status != null) {
-		switch (mea.Status.Category) {
-			case PNStatusCategory.PNUnexpectedDisconnectCategory:
-			case PNStatusCategory.PNTimeoutCategory:
-				// handle publish
-			break;
-		}
-	}
-	if (mea.MessageResult != null) {
-		Debug.Log("Channel" + mea.MessageResult.Channel);
-		Debug.Log("Payload" + mea.MessageResult.Payload);
-		Debug.Log("Publisher Id: " + mea.MessageResult.IssuingClientId);
-	}
-	if (mea.PresenceEventResult != null) {
-		Debug.Log("SubscribeCallback in presence" + mea.PresenceEventResult.Channel + mea.PresenceEventResult.Occupancy + mea.PresenceEventResult.Event);
-	}
-	if (mea.SignalEventResult != null) {					
-		Debug.Log ("SubscribeCallback in SignalEventResult" + mea.SignalEventResult.Channel + mea.SignalEventResult.Payload);
-	}
-	if (mea.UserEventResult != null) {					
-		Debug.Log(mea.UserEventResult.Name);
-		Debug.Log(mea.UserEventResult.Email);
-		Debug.Log(mea.UserEventResult.ExternalID);
-		Debug.Log(mea.UserEventResult.ProfileURL);
-		Debug.Log(mea.UserEventResult.UserID);
-		Debug.Log(mea.UserEventResult.ETag);
-		Debug.Log(mea.UserEventResult.ObjectsEvent);
-	}
-	if (mea.SpaceEventResult != null) {					
-		Debug.Log(mea.SpaceEventResult.Name);
-		Debug.Log(mea.SpaceEventResult.Description);
-		Debug.Log(mea.SpaceEventResult.SpaceID);
-		Debug.Log(mea.SpaceEventResult.ETag);
-		Debug.Log(mea.SpaceEventResult.ObjectsEvent);
-	} 
-	if (mea.MembershipEventResult != null) {					
-		Debug.Log(mea.MembershipEventResult.UserID);
-		Debug.Log(mea.MembershipEventResult.Description);
-		Debug.Log(mea.MembershipEventResult.SpaceID);
-		Debug.Log(mea.MembershipEventResult.ObjectsEvent);
-	}
-	if (mea.MessageActionsEventResult != null) {					
-		Debug.Log(mea.MessageActionsEventResult.Channel);
-		if(mea.MessageActionsEventResult.Data!=null){
-			Debug.Log(mea.MessageActionsEventResult.Data.ActionTimetoken);
-			Debug.Log(mea.MessageActionsEventResult.Data.ActionType);
-			Debug.Log(mea.MessageActionsEventResult.Data.ActionValue);
-			Debug.Log(mea.MessageActionsEventResult.Data.MessageTimetoken);
-			Debug.Log(mea.MessageActionsEventResult.Data.UUID);
-		}
-		Debug.Log(mea.MessageActionsEventResult.MessageActionsEvent);
-		Debug.Log(mea.MessageActionsEventResult.Subscription);
-	}
+    if (mea.Status != null) {
+        switch (mea.Status.Category) {
+            case PNStatusCategory.PNUnexpectedDisconnectCategory:
+            case PNStatusCategory.PNTimeoutCategory:
+                // handle publish
+            break;
+        }
+    }
+    if (mea.MessageResult != null) {
+        Debug.Log("Channel" + mea.MessageResult.Channel);
+        Debug.Log("Payload" + mea.MessageResult.Payload);
+        Debug.Log("Publisher Id: " + mea.MessageResult.IssuingClientId);
+    }
+    if (mea.PresenceEventResult != null) {
+        Debug.Log("SubscribeCallback in presence" + mea.PresenceEventResult.Channel + mea.PresenceEventResult.Occupancy + mea.PresenceEventResult.Event);
+    }
+    if (mea.SignalEventResult != null) {
+        Debug.Log ("SubscribeCallback in SignalEventResult" + mea.SignalEventResult.Channel + mea.SignalEventResult.Payload);
+    }
+    if (mea.UUIDEventResult != null) {
+        Debug.Log(mea.UUIDEventResult.Name);
+        Debug.Log(mea.UUIDEventResult.Email);
+        Debug.Log(mea.UUIDEventResult.ExternalID);
+        Debug.Log(mea.UUIDEventResult.ProfileURL);
+        Debug.Log(mea.UUIDEventResult.UUID);
+        Debug.Log(mea.UUIDEventResult.ETag);
+        Debug.Log(mea.UUIDEventResult.ObjectsEvent);
+    }
+    if (mea.ChannelEventResult != null) {
+        Debug.Log(mea.ChannelEventResult.Name);
+        Debug.Log(mea.ChannelEventResult.Description);
+        Debug.Log(mea.ChannelEventResult.ChannelID);
+        Debug.Log(mea.ChannelEventResult.ETag);
+        Debug.Log(mea.ChannelEventResult.ObjectsEvent);
+    }
+    if (mea.MembershipEventResult != null) {
+        Debug.Log(mea.MembershipEventResult.UUID);
+        Debug.Log(mea.MembershipEventResult.Description);
+        Debug.Log(mea.MembershipEventResult.ChannelID);
+        Debug.Log(mea.MembershipEventResult.ObjectsEvent);
+    }
+    if (mea.MessageActionsEventResult != null) {
+        Debug.Log(mea.MessageActionsEventResult.Channel);
+        if(mea.MessageActionsEventResult.Data!=null){
+            Debug.Log(mea.MessageActionsEventResult.Data.ActionTimetoken);
+            Debug.Log(mea.MessageActionsEventResult.Data.ActionType);
+            Debug.Log(mea.MessageActionsEventResult.Data.ActionValue);
+            Debug.Log(mea.MessageActionsEventResult.Data.MessageTimetoken);
+            Debug.Log(mea.MessageActionsEventResult.Data.UUID);
+        }
+        Debug.Log(mea.MessageActionsEventResult.MessageActionsEvent);
+        Debug.Log(mea.MessageActionsEventResult.Subscription);
+    }
 }
 ```
 
@@ -116,8 +137,7 @@ pubnub.Subscribe()
 
 ## Documentation
 
-* [Build your first realtime Unity app with PubNub](https://www.pubnub.com/docs/platform/quickstarts/unity)
-* [API reference for Unity](https://www.pubnub.com/docs/unity3d-c-sharp/pubnub-c-sharp-sdk)
+* [API reference for Unity](https://www.pubnub.com/docs/sdks/unity)
 
 ## Support
 


### PR DESCRIPTION
Update README to account for configuring PubNub Unity SDK in Unity applications for new Unity versions. Necessary, otherwise users cannot begin developing with the sdk. Updated event listeners with new changes. See changes [here](https://github.com/pubnub/sdk-documentation/commit/a640e9b7270fe26b6f49ad9bb9ad5c519bd1edd1).